### PR TITLE
use time.Duration and create GoNoUpdate()

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,14 @@ package main
 import (
 	"fmt"
 	"time"
-
 	"github.com/jftuga/TtlMap"
 )
 
 func main() {
-	maxTTL := 4                    // a key's time to live in seconds
-	startSize := 3                 // initial number of items in map
-	pruneInterval := 1             // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true // update item's 'lastAccessTime' on a .Get()
+	maxTTL := time.Duration(time.Second * 4)        // a key's time to live in seconds
+	startSize := 3                                  // initial number of items in map
+	pruneInterval := time.Duration(time.Second * 1) // search for expired items every 'pruneInterval' seconds
+	refreshLastAccessOnGet := true                  // update item's 'lastAccessTime' on a .Get()
 	t := TtlMap.New(maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
 	defer t.Close()
 
@@ -42,11 +41,12 @@ func main() {
 
 	sleepTime := maxTTL + pruneInterval
 	fmt.Printf("Sleeping %v seconds, items should be 'nil' after this time\n", sleepTime)
-	time.Sleep(time.Second * time.Duration(sleepTime))
+	time.Sleep(sleepTime)
 	fmt.Printf("[%9s] %v\n", "myString", t.Get("myString"))
 	fmt.Printf("[%9s] %v\n", "int_array", t.Get("int_array"))
 	fmt.Println("TtlMap length:", t.Len())
 }
+
 ```
 
 Output:
@@ -66,9 +66,12 @@ TtlMap length: 0
 
 ## API functions
 * `New`: initialize a `TtlMap`
+* `Close`: this stops the goroutine that checks for expired items; use with `defer`
 * `Len`: return the number of items in the map
 * `Put`: add a key/value
 * `Get`: get the current value of the given key; return `nil` if the key is not found in the map
+* `GetNoUpdate`: same as `Get`, but do not update the `lastAccess` expiration time
+* * * This ignores the `refreshLastAccessOnGet` parameter
 * `All`: returns a *copy* of all items in the map
 * `Delete`: delete an item; return `true` if the item was deleted, `false` if the item was not found in the map
 * `Clear`: remove all items from the map

--- a/example/example.go
+++ b/example/example.go
@@ -21,10 +21,10 @@ type User struct {
 }
 
 func main() {
-	maxTTL := 4                    // time in seconds
-	startSize := 3                 // initial number of items in map
-	pruneInterval := 1             // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true // update item's lastAccessTime on a .Get()
+	maxTTL := time.Duration(time.Second * 4)        // time in seconds
+	startSize := 3                                  // initial number of items in map
+	pruneInterval := time.Duration(time.Second * 1) // search for expired items every 'pruneInterval' seconds
+	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
 	t := TtlMap.New(maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
 	defer t.Close()
 
@@ -75,7 +75,7 @@ func main() {
 	fmt.Println()
 	fmt.Printf("Sleeping %v seconds, items should be removed after this time, except for the '%v' key\n", sleepTime, dontExpireKey)
 	fmt.Println()
-	time.Sleep(time.Second * time.Duration(sleepTime))
+	time.Sleep(sleepTime)
 
 	// these items have expired and therefore should be nil, except for 'dontExpireKey'
 	fmt.Printf("[%9s] %v\n", "string", t.Get("string"))
@@ -94,7 +94,7 @@ func main() {
 	if t.Get("int") == nil {
 		fmt.Println("[int] is nil")
 	}
-	fmt.Println("TtlMap length:", t.Len())
+	fmt.Println("TtlMap length:", t.Len(), " (should equal 1)")
 	fmt.Println()
 
 	fmt.Println()
@@ -104,14 +104,16 @@ func main() {
 	fmt.Printf("Manually deleting '%v' key again; should NOT be successful this time\n", dontExpireKey)
 	success = t.Delete(TtlMap.CustomKeyType(dontExpireKey))
 	fmt.Printf("    successful? %v\n", success)
-	fmt.Println("TtlMap length:", t.Len())
+	fmt.Println("TtlMap length:", t.Len(), " (should equal 0)")
 	fmt.Println()
 
 	fmt.Println("Adding 2 items and then running Clear()")
 	t.Put("string", "a b c")
 	t.Put("int", 3)
 	fmt.Println("TtlMap length:", t.Len())
-	fmt.Println("running Clear()")
+
+	fmt.Println()
+	fmt.Println("Running Clear()")
 	t.Clear()
 	fmt.Println("TtlMap length:", t.Len())
 	fmt.Println()

--- a/example/small/small.go
+++ b/example/small/small.go
@@ -8,10 +8,10 @@ import (
 )
 
 func main() {
-	maxTTL := 4                    // a key's time to live in seconds
-	startSize := 3                 // initial number of items in map
-	pruneInterval := 1             // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true // update item's 'lastAccessTime' on a .Get()
+	maxTTL := time.Duration(time.Second * 4)        // a key's time to live in seconds
+	startSize := 3                                  // initial number of items in map
+	pruneInterval := time.Duration(time.Second * 1) // search for expired items every 'pruneInterval' seconds
+	refreshLastAccessOnGet := true                  // update item's 'lastAccessTime' on a .Get()
 	t := TtlMap.New(maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
 	defer t.Close()
 
@@ -29,7 +29,7 @@ func main() {
 
 	sleepTime := maxTTL + pruneInterval
 	fmt.Printf("Sleeping %v seconds, items should be 'nil' after this time\n", sleepTime)
-	time.Sleep(time.Second * time.Duration(sleepTime))
+	time.Sleep(sleepTime)
 	fmt.Printf("[%9s] %v\n", "myString", t.Get("myString"))
 	fmt.Printf("[%9s] %v\n", "int_array", t.Get("int_array"))
 	fmt.Println("TtlMap length:", t.Len())

--- a/ttlMap_test.go
+++ b/ttlMap_test.go
@@ -7,18 +7,18 @@ import (
 )
 
 func TestAllItemsExpired(t *testing.T) {
-	maxTTL := 4                    // time in seconds
-	startSize := 3                 // initial number of items in map
-	pruneInterval := 1             // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true // update item's lastAccessTime on a .Get()
+	maxTTL := time.Duration(time.Second * 4)        // time in seconds
+	startSize := 3                                  // initial number of items in map
+	pruneInterval := time.Duration(time.Second * 1) // search for expired items every 'pruneInterval' seconds
+	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
 	tm := New(maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
+	defer tm.Close()
 
 	// populate the TtlMap
 	tm.Put("myString", "a b c")
 	tm.Put("int_array", []int{1, 2, 3})
 
-	sleepTime := maxTTL + pruneInterval
-	time.Sleep(time.Second * time.Duration(sleepTime))
+	time.Sleep(maxTTL + pruneInterval)
 	t.Logf("tm.len: %v\n", tm.Len())
 	if tm.Len() > 0 {
 		t.Errorf("t.Len should be 0, but actually equals %v\n", tm.Len())
@@ -26,18 +26,18 @@ func TestAllItemsExpired(t *testing.T) {
 }
 
 func TestNoItemsExpired(t *testing.T) {
-	maxTTL := 2                    // time in seconds
-	startSize := 3                 // initial number of items in map
-	pruneInterval := 3             // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true // update item's lastAccessTime on a .Get()
+	maxTTL := time.Duration(time.Second * 2)        // time in seconds
+	startSize := 3                                  // initial number of items in map
+	pruneInterval := time.Duration(time.Second * 3) // search for expired items every 'pruneInterval' seconds
+	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
 	tm := New(maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
+	defer tm.Close()
 
 	// populate the TtlMap
 	tm.Put("myString", "a b c")
 	tm.Put("int_array", []int{1, 2, 3})
 
-	sleepTime := maxTTL
-	time.Sleep(time.Second * time.Duration(sleepTime))
+	time.Sleep(maxTTL)
 	t.Logf("tm.len: %v\n", tm.Len())
 	if tm.Len() != 2 {
 		t.Fatalf("t.Len should equal 2, but actually equals %v\n", tm.Len())
@@ -45,11 +45,12 @@ func TestNoItemsExpired(t *testing.T) {
 }
 
 func TestKeepFloat(t *testing.T) {
-	maxTTL := 2                    // time in seconds
-	startSize := 3                 // initial number of items in map
-	pruneInterval := 1             // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true // update item's lastAccessTime on a .Get()
+	maxTTL := time.Duration(time.Second * 2)        // time in seconds
+	startSize := 3                                  // initial number of items in map
+	pruneInterval := time.Duration(time.Second * 1) // search for expired items every 'pruneInterval' seconds
+	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
 	tm := New(maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
+	defer tm.Close()
 
 	// populate the TtlMap
 	tm.Put("myString", "a b c")
@@ -63,8 +64,7 @@ func TestKeepFloat(t *testing.T) {
 		}
 	}()
 
-	sleepTime := maxTTL + pruneInterval
-	time.Sleep(time.Second * time.Duration(sleepTime))
+	time.Sleep(maxTTL + pruneInterval)
 	if tm.Len() != 1 {
 		t.Fatalf("t.Len should equal 1, but actually equals %v\n", tm.Len())
 	}
@@ -77,11 +77,12 @@ func TestKeepFloat(t *testing.T) {
 }
 
 func TestWithNoRefresh(t *testing.T) {
-	maxTTL := 4                     // time in seconds
-	startSize := 3                  // initial number of items in map
-	pruneInterval := 1              // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := false // do NOT update item's lastAccessTime on a .Get()
+	maxTTL := time.Duration(time.Second * 4)        // time in seconds
+	startSize := 3                                  // initial number of items in map
+	pruneInterval := time.Duration(time.Second * 1) // search for expired items every 'pruneInterval' seconds
+	refreshLastAccessOnGet := false                 // do NOT update item's lastAccessTime on a .Get()
 	tm := New(maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
+	defer tm.Close()
 
 	// populate the TtlMap
 	tm.Put("myString", "a b c")
@@ -94,8 +95,7 @@ func TestWithNoRefresh(t *testing.T) {
 		}
 	}()
 
-	sleepTime := maxTTL + pruneInterval
-	time.Sleep(time.Second * time.Duration(sleepTime))
+	time.Sleep(maxTTL + pruneInterval)
 	t.Logf("tm.Len: %v\n", tm.Len())
 	if tm.Len() != 0 {
 		t.Errorf("t.Len should be 0, but actually equals %v\n", tm.Len())
@@ -103,11 +103,12 @@ func TestWithNoRefresh(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	maxTTL := 2                    // time in seconds
-	startSize := 3                 // initial number of items in map
-	pruneInterval := 4             // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true // update item's lastAccessTime on a .Get()
+	maxTTL := time.Duration(time.Second * 2)        // time in seconds
+	startSize := 3                                  // initial number of items in map
+	pruneInterval := time.Duration(time.Second * 4) // search for expired items every 'pruneInterval' seconds
+	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
 	tm := New(maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
+	defer tm.Close()
 
 	// populate the TtlMap
 	tm.Put("myString", "a b c")
@@ -127,11 +128,12 @@ func TestDelete(t *testing.T) {
 }
 
 func TestClear(t *testing.T) {
-	maxTTL := 2                    // time in seconds
-	startSize := 3                 // initial number of items in map
-	pruneInterval := 4             // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true // update item's lastAccessTime on a .Get()
+	maxTTL := time.Duration(time.Second * 2)        // time in seconds
+	startSize := 3                                  // initial number of items in map
+	pruneInterval := time.Duration(time.Second * 4) // search for expired items every 'pruneInterval' seconds
+	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
 	tm := New(maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
+	defer tm.Close()
 
 	// populate the TtlMap
 	tm.Put("myString", "a b c")
@@ -149,11 +151,12 @@ func TestClear(t *testing.T) {
 }
 
 func TestAllFunc(t *testing.T) {
-	maxTTL := 2                    // time in seconds
-	startSize := 3                 // initial number of items in map
-	pruneInterval := 4             // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true // update item's lastAccessTime on a .Get()
+	maxTTL := time.Duration(time.Second * 2)        // time in seconds
+	startSize := 3                                  // initial number of items in map
+	pruneInterval := time.Duration(time.Second * 4) // search for expired items every 'pruneInterval' seconds
+	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
 	tm := New(maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
+	defer tm.Close()
 
 	// populate the TtlMap
 	tm.Put("myString", "a b c")
@@ -175,5 +178,34 @@ func TestAllFunc(t *testing.T) {
 	allItems := tm.All()
 	if !maps.Equal(allItems, tm.m) {
 		t.Fatalf("allItems and tm.m are not equal\n")
+	}
+}
+
+func TestGetNoUpdate(t *testing.T) {
+	maxTTL := time.Duration(time.Second * 2)        // time in seconds
+	startSize := 3                                  // initial number of items in map
+	pruneInterval := time.Duration(time.Second * 4) // search for expired items every 'pruneInterval' seconds
+	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
+	tm := New(maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
+	defer tm.Close()
+
+	// populate the TtlMap
+	tm.Put("myString", "a b c")
+	tm.Put("int", 1234)
+	tm.Put("floatPi", 3.1415)
+	tm.Put("int_array", []int{1, 2, 3})
+	tm.Put("boolean", true)
+
+	go func() {
+		for range time.Tick(time.Second) {
+			tm.GetNoUpdate("myString")
+			tm.GetNoUpdate("int_array")
+		}
+	}()
+
+	time.Sleep(maxTTL + pruneInterval)
+	t.Logf("tm.Len: %v\n", tm.Len())
+	if tm.Len() != 0 {
+		t.Errorf("t.Len should be 0, but actually equals %v\n", tm.Len())
 	}
 }


### PR DESCRIPTION
* Use `time.Duration` instead of `int` for `maxTTL` and `pruneInterval` parameters
* Change all examples and tests to use `time.Duration`
* Create `GetNoUpdate()` which is the same as `Get()`, except that is does not update the `lastAccess` expiration time
* * This ignores the `refreshLastAccessOnGet` parameter
* Create TestGetNoUpdate() function