### PR TITLE
Enhancement/generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TtlMap
 
 `TtlMap` is golang package that implements a *time-to-live* map such that after a given amount of time, items in the map are deleted.
-* The default map key uses a type of `string`, but this can be modified be changing `CustomKeyType` in [TtlMap.go](TtlMap.go).
+* The map key can be any [comparable](https://go.dev/ref/spec#Comparison_operators) data type, via Generics.
 * Any data type can be used as a map value. Internally, `interface{}` is used for this.
 
 ## Example
@@ -24,7 +24,7 @@ func main() {
 	startSize := 3                                  // initial number of items in map
 	pruneInterval := time.Duration(time.Second * 1) // search for expired items every 'pruneInterval' seconds
 	refreshLastAccessOnGet := true                  // update item's 'lastAccessTime' on a .Get()
-	t := TtlMap.New(maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
+	t := TtlMap.New[string](maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
 	defer t.Close()
 
 	// populate the TtlMap
@@ -46,7 +46,6 @@ func main() {
 	fmt.Printf("[%9s] %v\n", "int_array", t.Get("int_array"))
 	fmt.Println("TtlMap length:", t.Len())
 }
-
 ```
 
 Output:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ func main() {
 	startSize := 3                                  // initial number of items in map
 	pruneInterval := time.Duration(time.Second * 1) // search for expired items every 'pruneInterval' seconds
 	refreshLastAccessOnGet := true                  // update item's 'lastAccessTime' on a .Get()
+
+	// any comparable data type such as int, uint64, pointers and struct types (if all field types are comparable)
+	// can be used as the key type, not just string
 	t := TtlMap.New[string](maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
 	defer t.Close()
 
@@ -84,6 +87,7 @@ TtlMap length: 0
 * Adopted from: [Map with TTL option in Go](https://stackoverflow.com/a/25487392/452281)
 * * Answer created by: [OneOfOne](https://stackoverflow.com/users/145587/oneofone)
 * [/u/skeeto](https://old.reddit.com/user/skeeto): suggestions for the `New` function
+* `@zhayes` on the Go Discord: helping me with Go Generics
 
 ## Disclosure Notification
 

--- a/example/example.go
+++ b/example/example.go
@@ -25,7 +25,7 @@ func main() {
 	startSize := 3                                  // initial number of items in map
 	pruneInterval := time.Duration(time.Second * 1) // search for expired items every 'pruneInterval' seconds
 	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
-	t := TtlMap.New(maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
+	t := TtlMap.New[string](maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
 	defer t.Close()
 
 	// populate the TtlMap
@@ -66,7 +66,7 @@ func main() {
 	dontExpireKey := "float"
 	go func() {
 		for range time.Tick(time.Second) {
-			t.Get(TtlMap.CustomKeyType(dontExpireKey))
+			t.Get(dontExpireKey)
 		}
 	}()
 
@@ -99,10 +99,10 @@ func main() {
 
 	fmt.Println()
 	fmt.Printf("Manually deleting '%v' key; should be successful\n", dontExpireKey)
-	success := t.Delete(TtlMap.CustomKeyType(dontExpireKey))
+	success := t.Delete(dontExpireKey)
 	fmt.Printf("    successful? %v\n", success)
 	fmt.Printf("Manually deleting '%v' key again; should NOT be successful this time\n", dontExpireKey)
-	success = t.Delete(TtlMap.CustomKeyType(dontExpireKey))
+	success = t.Delete(dontExpireKey)
 	fmt.Printf("    successful? %v\n", success)
 	fmt.Println("TtlMap length:", t.Len(), " (should equal 0)")
 	fmt.Println()

--- a/example/small/small.go
+++ b/example/small/small.go
@@ -12,6 +12,9 @@ func main() {
 	startSize := 3                                  // initial number of items in map
 	pruneInterval := time.Duration(time.Second * 1) // search for expired items every 'pruneInterval' seconds
 	refreshLastAccessOnGet := true                  // update item's 'lastAccessTime' on a .Get()
+
+	// any comparable data type such as int, uint64, pointers and struct types (if all field types are comparable)
+	// can be used as the key type, not just string
 	t := TtlMap.New[string](maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
 	defer t.Close()
 

--- a/example/small/small.go
+++ b/example/small/small.go
@@ -12,7 +12,7 @@ func main() {
 	startSize := 3                                  // initial number of items in map
 	pruneInterval := time.Duration(time.Second * 1) // search for expired items every 'pruneInterval' seconds
 	refreshLastAccessOnGet := true                  // update item's 'lastAccessTime' on a .Get()
-	t := TtlMap.New(maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
+	t := TtlMap.New[string](maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
 	defer t.Close()
 
 	// populate the TtlMap

--- a/ttlMap.go
+++ b/ttlMap.go
@@ -22,7 +22,7 @@ import (
 	"time"
 )
 
-const version string = "1.4.0"
+const version string = "1.5.0"
 
 type CustomKeyType interface {
 	comparable


### PR DESCRIPTION
The TtlMap key can now be any [comparable](https://go.dev/ref/spec#Comparison_operators) data type.