### PR TITLE
Fix mem leak and update example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@
 
 # Go workspace file
 go.work
+
+.DS_STORE
+.idea/
+mem_*prof

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ TtlMap length: 0
 ## Performance
 * Searching for expired items runs in O(n) time, where n = number of items in the `TtlMap`.
 * * This inefficiency can be somewhat mitigated by increasing the value of the `pruneInterval` time.
-* In most cases you want `pruneInterval > maxTTL`; otherwise expired items will stay in the map longer than expected.
+* In most cases you want `pruneInterval < maxTTL` for faster cleanup of expired items. Setting `pruneInterval > maxTTL` reduces overhead but causes expired items to linger longer in the map.
 
 ## Acknowledgments
 * Adopted from: [Map with TTL option in Go](https://stackoverflow.com/a/25487392/452281)

--- a/example/example.go
+++ b/example/example.go
@@ -64,8 +64,13 @@ func main() {
 	// by executing Get(), the 'dontExpireKey' lastAccessTime will be updated
 	// therefore, this item will not expire
 	dontExpireKey := "float"
+
+	// Create a ticker that we can stop
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
 	go func() {
-		for range time.Tick(time.Second) {
+		for range ticker.C {
 			t.Get(dontExpireKey)
 		}
 	}()

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/jftuga/TtlMap
 
-go 1.21.3
+go 1.25.3

--- a/ttlMap.go
+++ b/ttlMap.go
@@ -22,7 +22,7 @@ import (
 	"time"
 )
 
-const version string = "1.5.1"
+const version string = "1.6.0"
 
 type CustomKeyType interface {
 	comparable
@@ -37,33 +37,31 @@ type TtlMap[T CustomKeyType] struct {
 	m       map[T]*item
 	l       sync.Mutex
 	refresh bool
-	stop    chan bool
+	done    chan struct{}
 }
 
 func New[T CustomKeyType](maxTTL time.Duration, ln int, pruneInterval time.Duration, refreshLastAccessOnGet bool) (m *TtlMap[T]) {
-	// if pruneInterval > maxTTL {
-	// 	print("WARNING: TtlMap: pruneInterval > maxTTL\n")
-	// }
-	m = &TtlMap[T]{m: make(map[T]*item, ln), stop: make(chan bool)}
+	m = &TtlMap[T]{m: make(map[T]*item, ln), done: make(chan struct{})}
 	m.refresh = refreshLastAccessOnGet
 	maxTTL /= 1000000000
-	// print("maxTTL: ", maxTTL, "\n")
+
 	go func() {
+		ticker := time.NewTicker(pruneInterval)
+		defer ticker.Stop() // Clean up the ticker when goroutine exits
+
 		for {
 			select {
-			case <-m.stop:
+			case <-m.done:
+				ticker.Stop()
 				return
-			case now := <-time.Tick(pruneInterval):
+			case now := <-ticker.C:
 				currentTime := now.Unix()
 				m.l.Lock()
 				for k, v := range m.m {
-					// print("TICK:", currentTime, "  ", v.lastAccess, "  ", currentTime-v.lastAccess, "  ", maxTTL, "  ", k, "\n")
 					if currentTime-v.lastAccess >= int64(maxTTL) {
 						delete(m.m, k)
-						// print("deleting: ", k, "\n")
 					}
 				}
-				// print("----\n")
 				m.l.Unlock()
 			}
 		}
@@ -129,5 +127,10 @@ func (m *TtlMap[T]) All() map[T]*item {
 }
 
 func (m *TtlMap[T]) Close() {
-	m.stop <- true
+	select {
+	case <-m.done:
+		// already closed; do nothing
+	default:
+		close(m.done)
+	}
 }

--- a/ttlMap_test.go
+++ b/ttlMap_test.go
@@ -1,141 +1,209 @@
+/*
+ttlMap_test.go
+
+Comprehensive test suite for TtlMap that combines memory leak detection,
+goroutine tracking, benchmarks, and functional tests for all TtlMap operations.
+*/
+
 package TtlMap
 
 import (
 	"maps"
+	"os"
+	"runtime"
+	"runtime/pprof"
 	"testing"
 	"time"
 )
 
-func TestAllItemsExpired(t *testing.T) {
-	maxTTL := time.Duration(time.Second * 4)        // time in seconds
-	startSize := 3                                  // initial number of items in map
-	pruneInterval := time.Duration(time.Second * 1) // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
-	tm := New[string](maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
-	defer tm.Close()
+// ====================
+// Memory Leak Detection Tests
+// ====================
 
-	// populate the TtlMap
-	tm.Put("myString", "a b c")
-	tm.Put("int_array", []int{1, 2, 3})
+// Test 1: Simple Memory Stats Test
+// Quick test to detect substantial memory growth
+func TestMemoryLeak(t *testing.T) {
+	var m runtime.MemStats
 
-	time.Sleep(maxTTL + pruneInterval)
-	t.Logf("tm.len: %v\n", tm.Len())
-	if tm.Len() > 0 {
-		t.Errorf("t.Len should be 0, but actually equals %v\n", tm.Len())
+	// Force GC and get baseline
+	runtime.GC()
+	runtime.ReadMemStats(&m)
+	baseline := m.Alloc
+
+	// Create and close 1000 TtlMaps
+	for i := 0; i < 1000; i++ {
+		ttlMap := New[string](5*time.Second, 10, 1*time.Second, true)
+		ttlMap.Put("key", "value")
+		ttlMap.Close()
+	}
+
+	// Force GC and check memory
+	runtime.GC()
+	time.Sleep(100 * time.Millisecond) // Give GC time to clean up
+	runtime.ReadMemStats(&m)
+	after := m.Alloc
+
+	growth := after - baseline
+	t.Logf("Memory baseline: %d bytes", baseline)
+	t.Logf("Memory after: %d bytes", after)
+	t.Logf("Memory growth: %d bytes", growth)
+
+	// If there's a leak, growth will be substantial (millions of bytes)
+	// Without leak, should be minimal (< 1 MB)
+	if growth > 1024*1024 {
+		t.Errorf("Potential memory leak detected: %d bytes growth", growth)
 	}
 }
 
-func TestNoItemsExpired(t *testing.T) {
-	maxTTL := time.Duration(time.Second * 2)        // time in seconds
-	startSize := 3                                  // initial number of items in map
-	pruneInterval := time.Duration(time.Second * 3) // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
-	tm := New[string](maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
-	defer tm.Close()
+// Test 2: Memory Profile with pprof
+// Creates before/after memory profiles for detailed analysis
+func TestMemoryLeakProfile(t *testing.T) {
+	// Create profile file
+	f, err := os.Create("mem_before.prof")
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime.GC()
+	pprof.WriteHeapProfile(f)
+	f.Close()
 
-	// populate the TtlMap
-	tm.Put("myString", "a b c")
-	tm.Put("int_array", []int{1, 2, 3})
+	// Create and close many TtlMaps
+	for i := 0; i < 10000; i++ {
+		ttlMap := New[string](5*time.Second, 10, 1*time.Second, true)
+		ttlMap.Put("key", "value")
+		ttlMap.Close()
+	}
 
-	time.Sleep(maxTTL)
-	t.Logf("tm.len: %v\n", tm.Len())
-	if tm.Len() != 2 {
-		t.Fatalf("t.Len should equal 2, but actually equals %v\n", tm.Len())
+	// Create after profile
+	f2, err := os.Create("mem_after.prof")
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime.GC()
+	time.Sleep(200 * time.Millisecond)
+	pprof.WriteHeapProfile(f2)
+	f2.Close()
+
+	t.Log("Memory profiles created: mem_before.prof and mem_after.prof")
+	t.Log("Run: go tool pprof -base=mem_before.prof mem_after.prof")
+}
+
+// Test 3: Goroutine Leak Check
+// Verifies that goroutines are properly cleaned up after Close()
+func TestGoroutineLeak(t *testing.T) {
+	baseline := runtime.NumGoroutine()
+
+	// Create and close 100 TtlMaps
+	for i := 0; i < 100; i++ {
+		ttlMap := New[string](5*time.Second, 10, 1*time.Second, true)
+		ttlMap.Close()
+	}
+
+	time.Sleep(100 * time.Millisecond) // Give goroutines time to exit
+
+	after := runtime.NumGoroutine()
+	leaked := after - baseline
+
+	t.Logf("Goroutines at start: %d", baseline)
+	t.Logf("Goroutines after: %d", after)
+	t.Logf("Leaked goroutines: %d", leaked)
+
+	// Should be 0 or very close (test goroutine itself may vary)
+	if leaked > 5 {
+		t.Errorf("Goroutine leak detected: %d goroutines not cleaned up", leaked)
 	}
 }
 
-func TestKeepFloat(t *testing.T) {
-	maxTTL := time.Duration(time.Second * 2)        // time in seconds
-	startSize := 3                                  // initial number of items in map
-	pruneInterval := time.Duration(time.Second * 1) // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
-	tm := New[string](maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
-	defer tm.Close()
+// Test 4: Benchmark with Memory Allocation
+// Measures performance and memory allocation per operation
+func BenchmarkTtlMapCreateDestroy(b *testing.B) {
+	b.ReportAllocs()
 
-	// populate the TtlMap
-	tm.Put("myString", "a b c")
-	tm.Put("int", 1234)
-	tm.Put("int_array", []int{1, 2, 3})
-
-	dontExpireKey := "int"
-	go func() {
-		for range time.Tick(time.Second) {
-			tm.Get(dontExpireKey)
-		}
-	}()
-
-	time.Sleep(maxTTL + pruneInterval)
-	if tm.Len() != 1 {
-		t.Fatalf("t.Len should equal 1, but actually equals %v\n", tm.Len())
-	}
-	all := tm.All()
-	if all[dontExpireKey].Value != 1234 {
-		t.Errorf("Value should equal 1234 but actually equals %v\n", all[dontExpireKey].Value)
-	}
-	t.Logf("tm.Len: %v\n", tm.Len())
-	t.Logf("%v Value: %v\n", dontExpireKey, all[dontExpireKey].Value)
-}
-
-func TestWithNoRefresh(t *testing.T) {
-	maxTTL := time.Duration(time.Second * 4)        // time in seconds
-	startSize := 3                                  // initial number of items in map
-	pruneInterval := time.Duration(time.Second * 1) // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := false                 // do NOT update item's lastAccessTime on a .Get()
-	tm := New[string](maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
-	defer tm.Close()
-
-	// populate the TtlMap
-	tm.Put("myString", "a b c")
-	tm.Put("int_array", []int{1, 2, 3})
-
-	go func() {
-		for range time.Tick(time.Second) {
-			tm.Get("myString")
-			tm.Get("int_array")
-		}
-	}()
-
-	time.Sleep(maxTTL + pruneInterval)
-	t.Logf("tm.Len: %v\n", tm.Len())
-	if tm.Len() != 0 {
-		t.Errorf("t.Len should be 0, but actually equals %v\n", tm.Len())
+	for i := 0; i < b.N; i++ {
+		ttlMap := New[string](5*time.Second, 10, 100*time.Millisecond, true)
+		ttlMap.Put("key", "value")
+		ttlMap.Close()
 	}
 }
 
-func TestDelete(t *testing.T) {
-	maxTTL := time.Duration(time.Second * 2)        // time in seconds
-	startSize := 3                                  // initial number of items in map
-	pruneInterval := time.Duration(time.Second * 4) // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
-	tm := New[string](maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
-	defer tm.Close()
+// ====================
+// Basic Functionality Tests
+// ====================
 
-	// populate the TtlMap
-	tm.Put("myString", "a b c")
-	tm.Put("int_array", []int{1, 2, 3})
+// Verify basic Put, Get, Delete, and TTL expiration
+func TestBasicFunctionality(t *testing.T) {
+	ttlMap := New[string](2*time.Second, 10, 500*time.Millisecond, true)
+	defer ttlMap.Close()
 
-	tm.Delete("int_array")
-	t.Logf("tm.len: %v\n", tm.Len())
-	if tm.Len() != 1 {
-		t.Fatalf("t.Len should equal 1, but actually equals %v\n", tm.Len())
+	// Test Put and Get
+	ttlMap.Put("key1", "value1")
+	val := ttlMap.Get("key1")
+	if val != "value1" {
+		t.Errorf("Expected 'value1', got '%v'", val)
 	}
 
-	tm.Delete("myString")
-	t.Logf("tm.len: %v\n", tm.Len())
-	if tm.Len() != 0 {
-		t.Fatalf("t.Len should equal 0, but actually equals %v\n", tm.Len())
+	// Test Len
+	if ttlMap.Len() != 1 {
+		t.Errorf("Expected length 1, got %d", ttlMap.Len())
+	}
+
+	// Test Delete
+	if !ttlMap.Delete("key1") {
+		t.Error("Expected Delete to return true")
+	}
+	if ttlMap.Len() != 0 {
+		t.Errorf("Expected length 0 after delete, got %d", ttlMap.Len())
+	}
+
+	// Test TTL expiration
+	ttlMap.Put("key2", "value2")
+	time.Sleep(2500 * time.Millisecond) // Wait for TTL + pruneInterval
+	val = ttlMap.Get("key2")
+	if val != nil {
+		t.Errorf("Expected key2 to be expired, but got '%v'", val)
 	}
 }
 
+// Test refresh functionality with Get() vs GetNoUpdate()
+func TestRefreshOnGet(t *testing.T) {
+	// Test with refresh enabled - use longer TTL for more reliable timing
+	ttlMap := New[int](5*time.Second, 10, 500*time.Millisecond, true)
+	defer ttlMap.Close()
+
+	ttlMap.Put(1, "value1")
+	time.Sleep(2 * time.Second)
+	ttlMap.Get(1)               // Should refresh lastAccess
+	time.Sleep(3 * time.Second) // Total: 5s, but lastAccess was refreshed at 2s
+	val := ttlMap.Get(1)
+	if val == nil {
+		t.Error("Expected key to still exist due to refresh on Get")
+	}
+
+	// Test GetNoUpdate - use fresh key with more margin
+	ttlMap.Put(2, "value2")
+	time.Sleep(2 * time.Second)
+	ttlMap.GetNoUpdate(2)               // Should NOT refresh lastAccess
+	time.Sleep(3500 * time.Millisecond) // Total: 5.5s > 5s TTL
+	val = ttlMap.Get(2)
+	if val != nil {
+		t.Error("Expected key to be expired since GetNoUpdate doesn't refresh")
+	}
+}
+
+// ====================
+// Additional Functional Tests
+// ====================
+
+// Test Clear() method
 func TestClear(t *testing.T) {
-	maxTTL := time.Duration(time.Second * 2)        // time in seconds
-	startSize := 3                                  // initial number of items in map
-	pruneInterval := time.Duration(time.Second * 4) // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
+	maxTTL := time.Duration(time.Second * 2)
+	startSize := 3
+	pruneInterval := time.Duration(time.Second * 4)
+	refreshLastAccessOnGet := true
 	tm := New[string](maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
 	defer tm.Close()
 
-	// populate the TtlMap
+	// Populate the TtlMap
 	tm.Put("myString", "a b c")
 	tm.Put("int_array", []int{1, 2, 3})
 	t.Logf("tm.len: %v\n", tm.Len())
@@ -150,15 +218,16 @@ func TestClear(t *testing.T) {
 	}
 }
 
+// Test All() method returns a proper copy
 func TestAllFunc(t *testing.T) {
-	maxTTL := time.Duration(time.Second * 2)        // time in seconds
-	startSize := 3                                  // initial number of items in map
-	pruneInterval := time.Duration(time.Second * 4) // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
+	maxTTL := time.Duration(time.Second * 2)
+	startSize := 3
+	pruneInterval := time.Duration(time.Second * 4)
+	refreshLastAccessOnGet := true
 	tm := New[string](maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
 	defer tm.Close()
 
-	// populate the TtlMap
+	// Populate the TtlMap
 	tm.Put("myString", "a b c")
 	tm.Put("int", 1234)
 	tm.Put("floatPi", 3.1415)
@@ -166,7 +235,6 @@ func TestAllFunc(t *testing.T) {
 	tm.Put("boolean", true)
 
 	tm.Delete("floatPi")
-	//t.Logf("tm.len: %v\n", tm.Len())
 	if tm.Len() != 4 {
 		t.Fatalf("t.Len should equal 4, but actually equals %v\n", tm.Len())
 	}
@@ -181,40 +249,35 @@ func TestAllFunc(t *testing.T) {
 	}
 }
 
-func TestGetNoUpdate(t *testing.T) {
-	maxTTL := time.Duration(time.Second * 2)        // time in seconds
-	startSize := 3                                  // initial number of items in map
-	pruneInterval := time.Duration(time.Second * 4) // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
+// Test multiple Put() operations on the same key
+func TestMultiplePuts(t *testing.T) {
+	maxTTL := time.Duration(time.Second * 2)
+	startSize := 3
+	pruneInterval := time.Duration(time.Second * 4)
+	refreshLastAccessOnGet := true
 	tm := New[string](maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
 	defer tm.Close()
 
-	// populate the TtlMap
-	tm.Put("myString", "a b c")
-	tm.Put("int", 1234)
-	tm.Put("floatPi", 3.1415)
-	tm.Put("int_array", []int{1, 2, 3})
-	tm.Put("boolean", true)
+	key := "example"
+	tm.Put(key, "original")
 
-	go func() {
-		for range time.Tick(time.Second) {
-			tm.GetNoUpdate("myString")
-			tm.GetNoUpdate("int_array")
-		}
-	}()
+	tm.Put(key, "revised")
+	if tm.Get(key) != "revised" {
+		t.Errorf("The '%v' should equal 'revised', but actually equals: '%v'\n", key, tm.Get(key))
+	}
 
-	time.Sleep(maxTTL + pruneInterval)
-	t.Logf("tm.Len: %v\n", tm.Len())
-	if tm.Len() != 0 {
-		t.Errorf("t.Len should be 0, but actually equals %v\n", tm.Len())
+	tm.Put(key, "revised-2")
+	if tm.Get(key) != "revised-2" {
+		t.Errorf("The '%v' should equal 'revised-2', but actually equals: '%v'\n", key, tm.Get(key))
 	}
 }
 
+// Test with uint64 keys to verify generic key types work
 func TestUInt64Key(t *testing.T) {
-	maxTTL := time.Duration(time.Second * 2)        // time in seconds
-	startSize := 3                                  // initial number of items in map
-	pruneInterval := time.Duration(time.Second * 4) // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
+	maxTTL := time.Duration(time.Second * 2)
+	startSize := 3
+	pruneInterval := time.Duration(time.Second * 4)
+	refreshLastAccessOnGet := true
 	tm := New[uint64](maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
 	defer tm.Close()
 
@@ -234,71 +297,125 @@ func TestUInt64Key(t *testing.T) {
 	}
 }
 
-func TestUFloat32Key(t *testing.T) {
-	maxTTL := time.Duration(time.Second * 2)        // time in seconds
-	startSize := 3                                  // initial number of items in map
-	pruneInterval := time.Duration(time.Second * 4) // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
-	tm := New[float32](maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
-	defer tm.Close()
-
-	tm.Put(34000000000.12345, "largest")
-	tm.Put(12312312312.98765, "mid")
-	tm.Put(0.001, "tiny")
-
-	allItems := tm.All()
-	for k, v := range allItems {
-		t.Logf("k: %v   v: %v\n", k, v.Value)
-	}
-	t.Logf("k: 0.001   v:%v   (verified)\n", tm.Get(0.001))
-
-	time.Sleep(maxTTL + pruneInterval)
-	t.Logf("tm.Len: %v\n", tm.Len())
-	if tm.Len() != 0 {
-		t.Errorf("t.Len should be 0, but actually equals %v\n", tm.Len())
-	}
-}
-
-func TestByteKey(t *testing.T) {
-	maxTTL := time.Duration(time.Second * 2)        // time in seconds
-	startSize := 3                                  // initial number of items in map
-	pruneInterval := time.Duration(time.Second * 4) // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
-	tm := New[byte](maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
-	defer tm.Close()
-
-	tm.Put(0x41, "A")
-	tm.Put(0x7a, "z")
-
-	allItems := tm.All()
-	for k, v := range allItems {
-		t.Logf("k: %x   v: %v\n", k, v.Value)
-	}
-	time.Sleep(maxTTL + pruneInterval)
-	t.Logf("tm.Len: %v\n", tm.Len())
-	if tm.Len() != 0 {
-		t.Errorf("t.Len should be 0, but actually equals %v\n", tm.Len())
-	}
-}
-
-func TestMultiplePuts(t *testing.T) {
-	maxTTL := time.Duration(time.Second * 2)        // time in seconds
-	startSize := 3                                  // initial number of items in map
-	pruneInterval := time.Duration(time.Second * 4) // search for expired items every 'pruneInterval' seconds
-	refreshLastAccessOnGet := true                  // update item's lastAccessTime on a .Get()
+// Test keeping one item alive via periodic Get() while others expire
+// This version properly cleans up the refresh goroutine to avoid leaks
+func TestKeepItemAlive(t *testing.T) {
+	maxTTL := time.Duration(time.Second * 2)
+	startSize := 3
+	pruneInterval := time.Duration(time.Second * 1)
+	refreshLastAccessOnGet := true
 	tm := New[string](maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
 	defer tm.Close()
 
-	key := "example"
-	tm.Put(key, "original")
+	// Populate the TtlMap
+	tm.Put("myString", "a b c")
+	tm.Put("int", 1234)
+	tm.Put("int_array", []int{1, 2, 3})
 
-	tm.Put(key, "revised")
-	if tm.Get(key) != "revised" {
-		t.Errorf("The '%v' should equal 'revised', but actually equals: '%v'\n", key, tm.Get(key))
+	dontExpireKey := "int"
+
+	// Create a ticker that we can stop
+	ticker := time.NewTicker(time.Second)
+	done := make(chan bool)
+
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				tm.Get(dontExpireKey)
+			}
+		}
+	}()
+
+	time.Sleep(maxTTL + pruneInterval)
+
+	// Stop the refresh goroutine
+	close(done)
+	time.Sleep(100 * time.Millisecond) // Give goroutine time to exit
+
+	if tm.Len() != 1 {
+		t.Fatalf("t.Len should equal 1, but actually equals %v\n", tm.Len())
+	}
+	all := tm.All()
+	if all[dontExpireKey].Value != 1234 {
+		t.Errorf("Value should equal 1234 but actually equals %v\n", all[dontExpireKey].Value)
+	}
+	t.Logf("tm.Len: %v\n", tm.Len())
+	t.Logf("%v Value: %v\n", dontExpireKey, all[dontExpireKey].Value)
+}
+
+// Test that with refreshLastAccessOnGet=false, items expire even if accessed
+func TestWithNoRefresh(t *testing.T) {
+	maxTTL := time.Duration(time.Second * 4)
+	startSize := 3
+	pruneInterval := time.Duration(time.Second * 1)
+	refreshLastAccessOnGet := false // Do NOT update item's lastAccessTime on a .Get()
+	tm := New[string](maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
+	defer tm.Close()
+
+	// Populate the TtlMap
+	tm.Put("myString", "a b c")
+	tm.Put("int_array", []int{1, 2, 3})
+
+	// Create a ticker that we can stop
+	ticker := time.NewTicker(time.Second)
+	done := make(chan bool)
+
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				tm.Get("myString")
+				tm.Get("int_array")
+			}
+		}
+	}()
+
+	time.Sleep(maxTTL + pruneInterval)
+
+	// Stop the refresh goroutine
+	close(done)
+	time.Sleep(100 * time.Millisecond) // Give goroutine time to exit
+
+	t.Logf("tm.Len: %v\n", tm.Len())
+	if tm.Len() != 0 {
+		t.Errorf("t.Len should be 0, but actually equals %v\n", tm.Len())
+	}
+}
+
+// Test Delete() method returns proper boolean values
+func TestDelete(t *testing.T) {
+	maxTTL := time.Duration(time.Second * 2)
+	startSize := 3
+	pruneInterval := time.Duration(time.Second * 4)
+	refreshLastAccessOnGet := true
+	tm := New[string](maxTTL, startSize, pruneInterval, refreshLastAccessOnGet)
+	defer tm.Close()
+
+	// Populate the TtlMap
+	tm.Put("myString", "a b c")
+	tm.Put("int_array", []int{1, 2, 3})
+
+	tm.Delete("int_array")
+	t.Logf("tm.len: %v\n", tm.Len())
+	if tm.Len() != 1 {
+		t.Fatalf("t.Len should equal 1, but actually equals %v\n", tm.Len())
 	}
 
-	tm.Put(key, "revised-2")
-	if tm.Get(key) != "revised-2" {
-		t.Errorf("The '%v' should equal 'revised-2', but actually equals: '%v'\n", key, tm.Get(key))
+	tm.Delete("myString")
+	t.Logf("tm.len: %v\n", tm.Len())
+	if tm.Len() != 0 {
+		t.Fatalf("t.Len should equal 0, but actually equals %v\n", tm.Len())
+	}
+
+	// Test deleting non-existent key
+	if tm.Delete("nonExistent") {
+		t.Error("Delete should return false for non-existent key")
 	}
 }


### PR DESCRIPTION
# Pull Request

* Fix memory leak reported in this [issue](https://github.com/jftuga/TtlMap/issues/9)
* Complete revamp of `ttlMap_test.go` which now includes profiling for memory leaks
* Small updates to `README.md` and `example.go`

## The Problem

It was using `time.Tick(pruneInterval)` which creates a ticker that never gets garbage collected. From the Go documentation, `time.Tick` is a convenience function that's only appropriate when the ticker will run for the entire lifetime of the application. Since a TtlMap can be closed via `Close()`, the ticker continues to leak even after the goroutine exits.

## The Fix

Replace time.Tick with `time.NewTicker`, which returns a `*time.Ticker` that can be explicitly stopped.

## Other Improvements

* More idiomatic by using `chan struct{}`
* More robust with safer `Close()` method
* More defensive (no panic on double-close)
